### PR TITLE
Add Origin header for CORS request

### DIFF
--- a/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
+++ b/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
@@ -105,6 +105,7 @@ public class AlternateConnections extends AbstractTest {
                 builder.get();
             } else {
                 builder.method("OPTIONS", null);
+                builder.header("Origin", "null");
             }
             final Response response = okHttpClient.newCall(builder.build()).execute();
             final Map<String, List<String>> headers = response.headers().toMultimap();


### PR DESCRIPTION
When a browser makes a CORS preflight (OPTIONS) request, it sends an Origin header.

Some plugins (e.g. mod_bosh for prosody) do not consider an OPTIONS request to be a CORS request if the Origin header is missing.

This change sends an `Origin: null` header when making an OPTIONS request. While `null` could be replaced with a specific origin before compilation, the current test is looking for an `Access-Control-Allow-Origin: *` response header so null should be fine.

[CORS for Developers - 7.4. Avoid returning Access-Control-Allow-Origin: "null"](https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null)